### PR TITLE
Isbn derives Hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ trait IsbnObject {
 /// assert_eq!("89-6626-126-4".parse(), Ok(isbn_10));
 /// assert_eq!("978-1-4920-6766-5".parse(), Ok(isbn_13));
 /// ```
-#[derive(Debug, PartialEq, Clone, Eq)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum Isbn {
     _10(Isbn10),


### PR DESCRIPTION
This commit adds `#[derive(Hash)]` to the `Isbn` enum.

While the underlying `Isbn10` and `Isbn13` types already derived `Hash`, the top-level `Isbn` enum did not. This prevented it from being used directly in hash-based collections like `HashMap` or `HashSet`.

This change makes the `Isbn` type more ergonomic by allowing it to be used as a key in a `HashMap`, which is a common use case.

Fixes #14 